### PR TITLE
Correct the issue with context menu closing in firefox

### DIFF
--- a/src/src/util/context.js
+++ b/src/src/util/context.js
@@ -61,8 +61,8 @@ define([
         }
 
         contextMenu = null;
-        top = e.clientY;
-        left = e.clientX;
+        top = e.clientY-1;
+        left = e.clientX-1;
         var $menu = $('<ul class="ci-contextmenu"></ul>').css({
           position: 'fixed',
           left: left,


### PR DESCRIPTION
There is a bug in Firefox (#1107) that in some conditions make the context menu disappear by itself. 
Shifting the menu 1 pixel to the left and top correct the problem and didn't seem to introduce any issue in Chromium.